### PR TITLE
Upgrade `carbon-components-svelte` to v0.86.0

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -15,7 +15,7 @@
 				"@sveltejs/kit": "^2.0.0",
 				"@sveltejs/vite-plugin-svelte": "^3.0.0",
 				"@types/eslint": "^9.6.0",
-				"carbon-components-svelte": "^0.85.2",
+				"carbon-components-svelte": "^0.86.0",
 				"carbon-icons-svelte": "^12.11.0",
 				"eslint": "^9.0.0",
 				"eslint-config-prettier": "^9.1.0",
@@ -1584,9 +1584,9 @@
 			}
 		},
 		"node_modules/carbon-components-svelte": {
-			"version": "0.85.2",
-			"resolved": "https://registry.npmjs.org/carbon-components-svelte/-/carbon-components-svelte-0.85.2.tgz",
-			"integrity": "sha512-+ta2wP9jugeDoDDHdzqbSomyEwtOaVyqVeCy5Z/q8WxdnahKOMDeIgPBi/QnsmsDIgS3+79svGG0BcBMBbCfYw==",
+			"version": "0.86.0",
+			"resolved": "https://registry.npmjs.org/carbon-components-svelte/-/carbon-components-svelte-0.86.0.tgz",
+			"integrity": "sha512-GThXFytKnMS8GXobVU70jS7/t8Kxp2jMW/FpvHZAJozcM96Y1w0sfUSHMsZIeD8Lf96FLdMlLdRK8ER7Zx1rbQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",

--- a/fe/package.json
+++ b/fe/package.json
@@ -16,7 +16,7 @@
 		"@sveltejs/kit": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",
 		"@types/eslint": "^9.6.0",
-		"carbon-components-svelte": "^0.85.2",
+		"carbon-components-svelte": "^0.86.0",
 		"carbon-icons-svelte": "^12.11.0",
 		"eslint": "^9.0.0",
 		"eslint-config-prettier": "^9.1.0",


### PR DESCRIPTION
Upgrades Carbon to the [latest version](https://github.com/carbon-design-system/carbon-components-svelte/releases/tag/v0.86.0).